### PR TITLE
Typo fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Backbone models and collections provide a hook called parse, which takes a singl
 You can use this hook to modify data then return the response.  But what if you have complicated transforms that need
 to occur?  Or what if you don't want bloated parse functions?  One approach you could take is to define a set of 
 pipes or filters.  The pipes in this case are going to be functions that take a response parameter, and return the modified output. 
-You can execute the pipes against the response sequentially by using a method such as underscore's combine function.
+You can execute the pipes against the response sequentially by using a method such as underscore's compose function.
 
 
 ```javascript

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ var pipes = {
             }
 };
 var PipedModel = Backbone.model.extend({
-            parse : _.combine(pipe1,pipe2)
+            parse : _.compose(pipes.pipe1, pipes.pipe2)
             
             });
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ var pipes = {
                      response.pipes = ['hello from pipe1'];
                      return response;
             },
-            pipe1 : function(response){
+            pipe2 : function(response){
                      response.pipes.push('hello from pipe2');
                      return response;
             }


### PR DESCRIPTION
Slightly confusingly (and syntactically incorrectly) the two pipes were both called pipe1 
Fixed in this commit.
